### PR TITLE
Improvement: Added a Markdown Parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ splitter = MarkdownSplitter()
 # From file
 sections = MarkdownSplitter.from_file('document.md')
 # From text
-sections = splitter.split_markdown(text)
+sections = splitter.split_text(text)
 ```
 
 ## MarkdownSection

--- a/markdown_chunkify/__init__.py
+++ b/markdown_chunkify/__init__.py
@@ -1,3 +1,4 @@
+from markdown_chunkify.utils.parsers import PyMuPDFMParser
 from markdown_chunkify.utils.splitters import MarkdownSplitter
 
-__all__ = ["MarkdownSplitter"]
+__all__ = ["MarkdownSplitter", "PyMuPDFMParser"]

--- a/markdown_chunkify/core/models.py
+++ b/markdown_chunkify/core/models.py
@@ -1,0 +1,31 @@
+from abc import ABC
+from abc import abstractmethod
+from pathlib import Path
+
+
+class BaseParser(ABC):
+    @abstractmethod
+    def to_markdown(self, file_path: str | Path) -> str:
+        """Parse file to markdown text.
+
+        Args:
+            file_path: Path to the file
+
+        Returns:
+            str: A Markdown formatted text.
+        """
+        pass
+
+
+class BaseSplitter(ABC):
+    @abstractmethod
+    def split_text(self, text: str) -> list[str]:
+        """Split text into chunks.
+
+        Args:
+            text: Text to split
+
+        Returns:
+            list[Any]: List of objects containing the split text, or the split text itself.
+        """
+        pass

--- a/markdown_chunkify/utils/parsers.py
+++ b/markdown_chunkify/utils/parsers.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+
+import pymupdf4llm
+
+from markdown_chunkify.core.models import BaseParser
+
+
+class PyMuPDFMParser(BaseParser):
+    """A wrapper around pymupdf4llm for parsing PDF files."""
+
+    @classmethod
+    def to_markdown(
+        self, file_path: str, destination_path: str | None = None, **kwargs
+    ) -> str:
+        """Convert PDF file to markdown text.
+
+        Args:
+            file_path (str): Path to the PDF file.
+            destination_path (str | None): Path to save the markdown file.
+                If a path is provided, the markdown file will be saved to that location.
+                If the directory does not exist, it will be created.
+
+        Returns:
+            str: A Markdown representation of the PDF file.
+        """
+        markdown = pymupdf4llm.to_markdown(file_path, **kwargs)
+
+        # Create the destination path if it doesn't exist
+        if destination_path:
+            if isinstance(destination_path, str):
+                destination_path = Path(destination_path)
+
+            destination_path.mkdir(parents=True, exist_ok=True)
+            file_name = Path(file_path).stem
+            markdown_output_path = destination_path / f"{file_name}.md"
+
+            # Save the markdown to the specified destination path
+            with open(markdown_output_path, "w", encoding="utf-8") as f:
+                f.write(markdown)
+
+        return markdown

--- a/markdown_chunkify/utils/splitters.py
+++ b/markdown_chunkify/utils/splitters.py
@@ -7,6 +7,8 @@ from pathlib import Path
 from typing import Optional
 from typing import Union
 
+from markdown_chunkify.core.models import BaseSplitter
+
 
 @dataclass
 class MarkdownSection:
@@ -46,16 +48,12 @@ class MarkdownSection:
         return json.dumps(asdict(self), indent=2)
 
 
-class MarkdownSplitter:
+class MarkdownSplitter(BaseSplitter):
     """A class for splitting Markdown text by headers while maintaining hierarchy."""
 
     def __init__(self):
         # Regex to capture both the header level (number of #) and the header text
         self._header_pattern = re.compile(r"^(#+)\s+(.+)$", re.MULTILINE)
-
-    def _get_header_level(self, header_marks: str) -> int:
-        """Get the level of the header based on number of # marks."""
-        return len(header_marks)
 
     def _find_parent_headers(
         self, current_level: int, header_stack: list[tuple[int, str]]
@@ -114,7 +112,7 @@ class MarkdownSplitter:
 
         return processed_text, replacement_map
 
-    def split_markdown(self, text: str) -> list[MarkdownSection]:
+    def split_text(self, text: str) -> list[MarkdownSection]:
         """Split Markdown text into sections while maintaining header hierarchy.
 
         Args:
@@ -137,7 +135,7 @@ class MarkdownSplitter:
         for i, match in enumerate(headers):
             header_marks = match.group(1)
             header_text = match.group(2).strip()
-            current_level = self._get_header_level(header_marks)
+            current_level = len(header_marks)
 
             # Extract section content (text between current header and next one)
             start_pos = match.end()
@@ -196,4 +194,4 @@ class MarkdownSplitter:
 
         splitter = cls()
         with path.open("r", encoding=encoding) as f:
-            return splitter.split_markdown(f.read())
+            return splitter.split_text(f.read())

--- a/poetry.lock
+++ b/poetry.lock
@@ -176,12 +176,12 @@ version = "0.4.6"
 description = "Cross-platform colored terminal text."
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
-groups = ["main", "dev"]
+groups = ["dev"]
+markers = "sys_platform == \"win32\" or platform_system == \"Windows\""
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
-markers = {main = "sys_platform == \"win32\"", dev = "sys_platform == \"win32\" or platform_system == \"Windows\""}
 
 [[package]]
 name = "comm"
@@ -207,7 +207,7 @@ version = "7.6.11"
 description = "Code coverage measurement for Python"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["dev"]
 files = [
     {file = "coverage-7.6.11-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:eafea49da254a8289bed3fab960f808b322eda5577cb17a3733014928bbfbebd"},
     {file = "coverage-7.6.11-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5a3f7cbbcb4ad95067a6525f83a6fc78d9cbc1e70f8abaeeaeaa72ef34f48fc3"},
@@ -340,7 +340,7 @@ version = "2.0.0"
 description = "brain-dead simple config-ini parsing"
 optional = false
 python-versions = ">=3.7"
-groups = ["main", "dev"]
+groups = ["dev"]
 files = [
     {file = "iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
     {file = "iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3"},
@@ -541,7 +541,7 @@ version = "24.2"
 description = "Core utilities for Python packages"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev"]
+groups = ["dev"]
 files = [
     {file = "packaging-24.2-py3-none-any.whl", hash = "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759"},
     {file = "packaging-24.2.tar.gz", hash = "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f"},
@@ -614,7 +614,7 @@ version = "1.5.0"
 description = "plugin and hook calling mechanisms for python"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev"]
+groups = ["dev"]
 files = [
     {file = "pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669"},
     {file = "pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1"},
@@ -727,12 +727,44 @@ files = [
 windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
+name = "pymupdf"
+version = "1.25.3"
+description = "A high performance Python library for data extraction, analysis, conversion & manipulation of PDF (and other) documents."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "pymupdf-1.25.3-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:96878e1b748f9c2011aecb2028c5f96b5a347a9a91169130ad0133053d97915e"},
+    {file = "pymupdf-1.25.3-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:6ef753005b72ebfd23470f72f7e30f61e21b0b5e748045ec5b8f89e6e3068d62"},
+    {file = "pymupdf-1.25.3-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:46d90c4f9e62d1856e8db4b9f04a202ff4a7f086a816af73abdc86adb7f5e25a"},
+    {file = "pymupdf-1.25.3-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a5de51efdbe4d486b6c1111c84e8a231cbfb426f3d6ff31ab530ad70e6f39756"},
+    {file = "pymupdf-1.25.3-cp39-abi3-win32.whl", hash = "sha256:bca72e6089f985d800596e22973f79cc08af6cbff1d93e5bda9248326a03857c"},
+    {file = "pymupdf-1.25.3-cp39-abi3-win_amd64.whl", hash = "sha256:4fb357438c9129fbf939b5af85323434df64e36759c399c376b62ad6da95498c"},
+    {file = "pymupdf-1.25.3.tar.gz", hash = "sha256:b640187c64c5ac5d97505a92e836da299da79c2f689f3f94a67a37a493492193"},
+]
+
+[[package]]
+name = "pymupdf4llm"
+version = "0.0.17"
+description = "PyMuPDF Utilities for LLM/RAG"
+optional = false
+python-versions = "*"
+groups = ["main"]
+files = [
+    {file = "pymupdf4llm-0.0.17-py3-none-any.whl", hash = "sha256:26de9996945f15e3ca507908f80dc18a959f5b5214bb2e302c7f7034089665a0"},
+    {file = "pymupdf4llm-0.0.17.tar.gz", hash = "sha256:27287ef9fe0217cf37841a3ef2bcf70da2553c43d95ea39b664a6de6485678c3"},
+]
+
+[package.dependencies]
+pymupdf = ">=1.24.10"
+
+[[package]]
 name = "pytest"
 version = "7.4.4"
 description = "pytest: simple powerful testing with Python"
 optional = false
 python-versions = ">=3.7"
-groups = ["main", "dev"]
+groups = ["dev"]
 files = [
     {file = "pytest-7.4.4-py3-none-any.whl", hash = "sha256:b090cdf5ed60bf4c45261be03239c2c1c22df034fbffe691abe93cd80cea01d8"},
     {file = "pytest-7.4.4.tar.gz", hash = "sha256:2cf0005922c6ace4a3e2ec8b4080eb0d9753fdc93107415332f50ce9e7994280"},
@@ -753,7 +785,7 @@ version = "6.0.0"
 description = "Pytest plugin for measuring coverage."
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["dev"]
 files = [
     {file = "pytest-cov-6.0.0.tar.gz", hash = "sha256:fde0b595ca248bb8e2d76f020b465f3b107c9632e6a1d1705f17834c89dcadc0"},
     {file = "pytest_cov-6.0.0-py3-none-any.whl", hash = "sha256:eee6f1b9e61008bd34975a4d5bab25801eb31898b032dd55addc93e96fcaaa35"},
@@ -1044,4 +1076,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.13"
-content-hash = "266484eb52972b16311a4598160ba7914811e92f4e58119209d48b1956b31295"
+content-hash = "d45b57e069f51b78f22c84691d153c22d285cd98b4fe8f88c5d95b28925ef394"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 packages = [{include = "markdown_chunkify"}]
 readme = "README.md"
 requires-python = ">=3.12,<3.13"
-dependencies = []
+dependencies = ["pymupdf4llm (>=0.0.17,<0.0.18)"]
 
 [project.urls]
 Github = "https://github.com/Gal-Gilor/markdown-chunkify"


### PR DESCRIPTION
### Summary

- [Updated split_markdown with split_text in example usage](https://github.com/Gal-Gilor/markdown-chunkify/commit/a50daa8c790e29c32f55f09440c07a794b3d4dde)
- [Added pymupdf4llm to dependecies](https://github.com/Gal-Gilor/markdown-chunkify/commit/e330d9bc7abc8ffc3b6cf8d8ccac03aab21fe2b4)
- [Defined interfaces for splitters and parsers.](https://github.com/Gal-Gilor/markdown-chunkify/commit/76fcde7c2733174339280aabe633ee77a13b3bb2)
- [Added a pymupdf parser to utils.](https://github.com/Gal-Gilor/markdown-chunkify/commit/4084e0b80909223d20982ebe891ec5a81e58c8a1)