### PR TITLE
Rename `GeminiNormalizer` to `UnicodeReplaceProcessor`

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ poetry run pytest tests -vv
 
 ### Environment Variables
 
-The following environment variables are required for the `GeminiNormalizer` component.
+The following environment variables are required for the `UnicodeReplaceProcessor` component.
 
 | Variable | Description | Default |
 |----------|-------------|---------|

--- a/markdown_chunkify/__init__.py
+++ b/markdown_chunkify/__init__.py
@@ -1,5 +1,5 @@
-from markdown_chunkify.components.normalizers import GeminiNormalizer
 from markdown_chunkify.components.parsers import PyMuPDFMParser
+from markdown_chunkify.components.processors import GeminiNormalizer
 from markdown_chunkify.components.splitters import MarkdownSplitter
 
 __all__ = ["MarkdownSplitter", "PyMuPDFMParser", "GeminiNormalizer"]

--- a/markdown_chunkify/__init__.py
+++ b/markdown_chunkify/__init__.py
@@ -1,5 +1,5 @@
 from markdown_chunkify.components.parsers import PyMuPDFMParser
-from markdown_chunkify.components.processors import GeminiNormalizer
+from markdown_chunkify.components.processors import UnicodeReplaceProcessor
 from markdown_chunkify.components.splitters import MarkdownSplitter
 
-__all__ = ["MarkdownSplitter", "PyMuPDFMParser", "GeminiNormalizer"]
+__all__ = ["MarkdownSplitter", "PyMuPDFMParser", "UnicodeReplaceProcessor"]

--- a/markdown_chunkify/components/processors.py
+++ b/markdown_chunkify/components/processors.py
@@ -9,7 +9,7 @@ from tenacity import stop_after_attempt
 from tenacity import wait_random_exponential
 from vertexai.generative_models import GenerationResponse
 
-from markdown_chunkify.core.interfaces import BaseNormalizer
+from markdown_chunkify.core.interfaces import BaseProcessor
 from markdown_chunkify.core.models import MarkdownContent
 from markdown_chunkify.core.models import Section
 from markdown_chunkify.core.models import SectionMetadata
@@ -51,7 +51,7 @@ DEFAULT_GENERATION_CONFIG = types.GenerateContentConfig(
 )
 
 
-class GeminiNormalizer(BaseNormalizer):
+class UnicodeReplaceProcessor(BaseProcessor):
     """A Gemini powered class to process Markdown text."""
 
     def __init__(
@@ -61,7 +61,7 @@ class GeminiNormalizer(BaseNormalizer):
         instructions: str | None = None,
         retry_config: RetryConfig | None = None,
     ):
-        """Initialize the normalizer.
+        """Initialize the UnicodeReplaceProcessor.
 
         Args:
             model (genai.GenerativeModel): A GenerativeModel instance.
@@ -90,7 +90,7 @@ class GeminiNormalizer(BaseNormalizer):
             retry_error_callback=self.retry_config.retry_error_callback,
         )
 
-    def normalize_unicode(self, section: Section) -> Section:
+    def process_text(self, section: Section) -> Section:
         """Wrapper method to normalize Unicode characters in Markdown.
 
         Args:

--- a/markdown_chunkify/core/interfaces.py
+++ b/markdown_chunkify/core/interfaces.py
@@ -35,9 +35,9 @@ class BaseSplitter(ABC):
         pass
 
 
-class BaseNormalizer(ABC, Generic[T]):
+class BaseProcessor(ABC, Generic[T]):
     @abstractmethod
-    def normalize_unicode(self, content: T) -> T:
+    def process_text(self, section: T) -> T:
         """Normalize Unicode characters.
 
         Args:


### PR DESCRIPTION
### Summary of Changes
- Renamed the `BaseNormalizer` interface to `BaseProcessor`