### PR TITLE
Simplified UnicodeReplaceProcessor 

### DIFF
--- a/markdown_chunkify/core/models.py
+++ b/markdown_chunkify/core/models.py
@@ -1,5 +1,8 @@
+import re
+
 from pydantic import BaseModel
 from pydantic import Field
+from pydantic import field_validator
 
 
 class MarkdownContent(BaseModel):
@@ -7,6 +10,11 @@ class MarkdownContent(BaseModel):
 
     section_header: str = Field(..., description="The Markdown section header")
     section_text: str = Field(..., description="The Markdown section content")
+
+    @field_validator("section_header")
+    def clean_section_header(cls, value):
+        """Remove leading and trailing whitespace from the section header."""
+        return re.sub(r"^#+\s*", "", value)
 
 
 class SectionMetadata(BaseModel):


### PR DESCRIPTION
### Summary of Changes
- Removed the non-public metadata generation method from UnicodeReplaceProcessor
- Introduced a field validation on the `section_header` field to remove leading pound signs.